### PR TITLE
feat: [CXX-15322] Add option to send account id

### DIFF
--- a/src/components/Instance.js
+++ b/src/components/Instance.js
@@ -28,7 +28,8 @@ export class Instance extends React.PureComponent {
         instanceState: undefined,
         configWizardSrc: undefined,
         authExternalId: undefined,
-        authUrlParams: ''
+        authUrlParams: '',
+        accountId: ''
     };
 
     openWizard = (openInIframe, addCustomValidation = false) => {
@@ -78,7 +79,7 @@ export class Instance extends React.PureComponent {
     onCreateAuth = () => {
         getAuthCreateUrl(this.props.id, this.state.authExternalId)
             .then(({body}) => {
-                openAuthWindow(`${body.data.popupUrl}&${this.state.authUrlParams}`);
+                openAuthWindow(`${body.data.popupUrl}&${this.state.authUrlParams}`, this.state.accountId);
             })
     };
 
@@ -198,6 +199,15 @@ export class Instance extends React.PureComponent {
                                 label="Advanced Url Params"
                                 value={this.state.authUrlParams}
                                 onChange={this.handleChange('authUrlParams')}
+                                InputLabelProps={{
+                                    shrink: true,
+                                }}
+                            />
+                            <TextField
+                                style={styles.textFields}
+                                label="Account id (For use with enhanced session transfer security)"
+                                value={this.state.accountId}
+                                onChange={this.handleChange('accountId')}
                                 InputLabelProps={{
                                     shrink: true,
                                 }}

--- a/src/lib/authWindow.js
+++ b/src/lib/authWindow.js
@@ -1,36 +1,46 @@
-export const openAuthWindow = (url) => {
-    // Must open window from user interaction code otherwise it is likely
-    // to be blocked by a popup blocker:
-    const authWindow = window.open(
-        undefined,
-        '_blank',
-        'width=500,height=500,scrollbars=no',
-    );
+export const openAuthWindow = (url, accountId) => {
+  // Must open window from user interaction code otherwise it is likely
+  // to be blocked by a popup blocker:
+  const authWindow = window.open(
+    undefined,
+    "_blank",
+    "width=500,height=500,scrollbars=no"
+  );
 
-    const onmessage = e => {
-        console.log('message', e.data.type, e.data);
+  const onmessage = (e) => {
 
-        if (e.data.type === 'tray.authPopup.error') {
-            // Handle popup error message
-            alert(`Error: ${e.data.error}`);
-            authWindow.close();
-        }
-        if (e.data.type === 'tray.authpopup.close' || e.data.type === 'tray.authpopup.finish') {
-            authWindow.close();
-        }
-    };
-    window.addEventListener('message', onmessage);
-
-    // Check if popup window has been closed
-    const CHECK_TIMEOUT = 1000;
-    const checkClosedWindow = () => {
-        if (authWindow.closed) {
-            window.removeEventListener('message', onmessage);
-        } else {
-            setTimeout(checkClosedWindow, CHECK_TIMEOUT);
-        }
+    if(e.data.type === "tray.authpopup.accountIdRequest"){
+        // If the user has the enhancedSessionSecurity option set, they will send a postMessage
+        // requesting the account ID. Unless the client app responds with the appropriate ID
+        // the session will not be validated
+        e.source.postMessage({type: 'tray.authpopup.accountIdRequest', data: accountId},
+                           e.origin);
     }
 
-    checkClosedWindow();
-    authWindow.location = url;
+    if (e.data.type === "tray.authPopup.error") {
+      // Handle popup error message
+      alert(`Error: ${e.data.error}`);
+      authWindow.close();
+    }
+    if (
+      e.data.type === "tray.authpopup.close" ||
+      e.data.type === "tray.authpopup.finish"
+    ) {
+    //   authWindow.close();
+    }
+  };
+  window.addEventListener("message", onmessage);
+
+  // Check if popup window has been closed
+  const CHECK_TIMEOUT = 1000;
+  const checkClosedWindow = () => {
+    if (authWindow.closed) {
+      window.removeEventListener("message", onmessage);
+    } else {
+      setTimeout(checkClosedWindow, CHECK_TIMEOUT);
+    }
+  };
+
+  checkClosedWindow();
+  authWindow.location = url;
 };


### PR DESCRIPTION
Adds the option with the sample app to send an account ID to the auth pop up.

This is to enable testing of the `enhancedSessionSecurity` setting that validates the session token. When this setting is enabled the BE will not validate the session unless the correct account ID is provided.